### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gerlero/add-apt-repository/security/code-scanning/1](https://github.com/gerlero/add-apt-repository/security/code-scanning/1)

To fix the issue, add an explicit `permissions` block to restrict the GITHUB_TOKEN from having unnecessary access. Since the workflow only checks out the code and installs packages (with no evidence of write requirements), the minimal required permission is likely `contents: read`, which allows the jobs to clone/read the repository. The most effective and flexible way is to add the `permissions` block at the root of the workflow (at the very top, after the `name:` and before `on:` blocks), so it applies to all jobs unless specifically overridden. Edit the `.github/workflows/ci.yml` file to add:

```yml
permissions:
  contents: read
```

right after the `name: CI` line.

No new imports, methods, or definitions are involved. If future jobs need broader permissions, further entries can be added to the `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
